### PR TITLE
Add Dojo templates

### DIFF
--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -1,0 +1,260 @@
+{{- /* dojo.subject.stable_text(Data) */ -}}
+{{- /* This provides a stable subject value that is only a function of the static */ -}}
+{{- /* values used to group the alerts being notified (GroupLabels). */ -}}
+{{- /* It does NOT make use of the number of alerts, common labels across firing */ -}}
+{{- /* alerts (CommonLabels) or annotations (CommonAnnotations). All these values */ -}}
+{{- /* can change as new alerts fire and old alerts resolve, making the subject */ -}}
+{{- /* value change as well. */ -}}
+{{- /* Having a stable subject is good for use cases where the grouped alerts state */ -}}
+{{- /* is to me synchronised with another system (eg: PagerDuty), and we */ -}}
+{{- /* want to prevent a stale subject from misleading people. */ -}}
+{{- /* Examples: */ -}}
+{{- /* "Alerts for $receiver" */ -}}
+{{- /* "[$alertname_value] ($group_label_key=$group_label_value)" */ -}}
+{{- /* "($group_label_key=$group_label_value)" */ -}}
+{{- define "dojo.subject.stable_text" -}}
+	{{- if eq .Status "resolved" -}}
+		{{- "Resolved: " -}}
+	{{- end -}}
+	{{- with .GroupLabels -}}
+		{{- $groupLabels := . -}}
+		{{- with index . "alertname" -}}
+			{{- "[" }}{{ . }}{{ "]" -}}
+		{{- end -}}
+		{{- with .Remove (stringSlice "alertname") -}}
+			{{- with index $groupLabels "alertname" -}}
+				{{- " " -}}
+			{{- end -}}
+			{{ "(" }}
+			{{- with index .SortedPairs 0 -}}
+				{{- .Name }}={{ .Value -}}
+			{{- end -}}
+			{{- with slice .SortedPairs 1 -}}
+				{{- range . -}}
+					{{- " " }}{{ .Name }}={{ .Value -}}
+				{{- end -}}
+			{{- end -}}
+			{{ ")" }}
+		{{- end -}}
+	{{- else -}}
+		{{- "Alerts for " -}}{{- .Receiver -}}
+	{{- end -}}
+{{- end -}}
+
+{{- /* dojo.alert.text(Alert) */ -}}
+{{- /* Textual representation of the Alert with: */ -}}
+{{- /* - A descriptive "alert name": */ -}}
+{{- /*   - "[$alertname_value] ($label=$value)" when "alertname" label exists. */ -}}
+{{- /*   - "($label=$value)" when "alertname" is missing. */ -}}
+{{- /* - Annotations */ -}}
+{{- define "dojo.alert.text" -}}
+	{{- $alert := . -}}
+	{{- with index .Labels.alertname -}}
+		{{- "[" -}}{{ . }}{{- "]" -}}
+		{{- with ($alert.Labels.Remove (stringSlice "alertname")).SortedPairs -}}
+			{{- " (" }}
+			{{- with index . 0 -}}
+				{{- .Name }}={{ .Value -}}
+			{{- end -}}
+			{{- range slice . 1 -}}
+				{{- " " }}{{ .Name }}={{ .Value -}}
+			{{- end -}}
+			{{- ")" }}
+		{{- end -}}
+	{{- else -}}
+		{{- "(" -}}
+			{{- with index $alert.Labels.SortedPairs 0 -}}
+				{{- .Name }}={{ .Value -}}
+			{{- end -}}
+			{{- with slice $alert.Labels.SortedPairs 1 -}}
+				{{- range . -}}
+					{{- " " }}{{ .Name }}={{ .Value -}}
+				{{- end -}}
+			{{- end -}}
+		{{- ")" -}}
+	{{- end -}}
+	{{- with .Annotations.SortedPairs -}}
+		{{- "\nAnnotations:" -}}
+		{{- range . -}}
+			{{ "\n" }}{{ .Name }}: {{ .Value }}
+		{{- end -}}
+	{{- end -}}
+	{{- with .GeneratorURL -}}
+		{{ "\n" }}{{ . }}
+	{{- end -}}
+{{- end -}}
+
+{{- /* dojo.alerts.text(Alerts) */ -}}
+{{- /* Textual representation of a list of Alerts. */ -}}
+{{- /* See also: dojo.alert.text */ -}}
+{{- /* See also: dojo.alerts.status_grouped_text */ -}}
+{{- define "dojo.alerts.text" -}}
+	{{- with . -}}
+		{{- with index . 0 -}}
+			{{- template "dojo.alert.text" . -}}
+		{{- end -}}
+		{{- with slice . 1 -}}
+			{{- range . -}}
+				{{- "\n\n" }}
+				{{- template "dojo.alert.text" . -}}
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
+{{- end -}}
+
+{{- /* dojo.alerts.status_grouped_text(Alerts) */ -}}
+{{- /* Textual representation of a list of Alerts with status */ -}}
+{{- /* (firing / resolved) grouping. */ -}}
+{{- /* See also: dojo.alert.text */ -}}
+{{- /* See also: dojo.alerts.text */ -}}
+{{- define "dojo.alerts.status_grouped_text" -}}
+	{{- if and (gt (len .Firing) 0) (gt (len .Resolved) 0)  }}
+		{{- $alerts := . -}}
+		{{- with .Firing -}}
+			{{- "FIRING:\n\n" -}}
+			{{- template "dojo.alerts.text" . -}}
+		{{- end -}}
+		{{- with .Resolved -}}
+			{{- with $alerts.Firing -}}
+				{{- "\n\n" -}}
+			{{- end -}}
+			{{- "RESOLVED:\n\n" -}}
+			{{- template "dojo.alerts.text" . -}}
+		{{- end -}}
+	{{- else -}}
+		{{- template "dojo.alerts.text" .Firing -}}
+		{{- template "dojo.alerts.text" .Resolved -}}
+	{{- end -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.firing(Data) */ -}}
+{{- /* URL that points to Grafana Labs list of firing alerts. */ -}}
+{{- define "dojo.alerts.url.firing" -}}
+	{{- "https://paymentsense.grafana.net/alerting/list?" }}
+		{{- "dataSource=DATASOURCE_NAME" -}}
+		{{- "&queryString=" -}}
+			{{- /* tenant is a mandatory field for all configured alerts, */ -}}
+			{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+			{{- "tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "," -}}
+			{{- /* urgency is to become mandatory via CI... */ -}}
+			{{- with .CommonLabels.urgency -}}
+				{{- "urgency%3D" -}}{{- . | urlquery -}}{{- "," -}}
+			{{- /* ...until then, we must account for when it is missing. */ -}}
+			{{- else -}}
+				{{- "urgency!~%5E(high%7Clow)$," -}}
+			{{- end -}}
+			{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
+				{{- range .SortedPairs -}}
+					{{- .Name | urlquery -}}{{- "%3D" -}}{{- .Value | urlquery -}}{{- "," -}}
+				{{- end -}}
+			{{- end -}}
+		{{- "&ruleType=alerting" -}}
+		{{- "&alertState=firing" -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.history(Data) */ -}}
+{{- /* URL that points to a Grafana Labs Dashboard with the history of alerts */ -}}
+{{- define "dojo.alerts.url.history" -}}
+	{{- "https://paymentsense.grafana.net/d/luyBQ9Y7z/?" -}}
+		{{- "orgId=1&" -}}
+		{{- "var-data_source=DATASOURCE_NAME&" -}}
+		{{- /* tenant is a mandatory field for all configured alerts, */ -}}
+		{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+		{{- "var-tenant=" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
+		{{- /* urgency is to become mandatory via CI... */ -}}
+		{{- with .CommonLabels.urgency -}}
+			{{- "var-urgency=" -}}{{- . | urlquery -}}{{- "&" -}}
+		{{- /* ...until then, we must account for when it is missing. */ -}}
+		{{- else -}}
+			{{- "var-label=urgency%7C!~%7C%5E(high__gfp__low)$" -}}{{- "&" -}}
+		{{- end -}}
+		{{- /* alertname MAY be part of grouped labels */ -}}
+		{{- with .GroupLabels.alertname -}}
+			{{- "var-alertname=" -}}{{- . | urlquery -}}{{- "&" -}}
+		{{- end -}}
+		{{- /* Add any other group labels other than the ones already set */ -}}
+		{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency" "alertname") -}}
+			{{- range .SortedPairs -}}
+				{{- "var-label=" -}}
+					{{- .Name | urlquery -}}
+					{{- "%7C%3D%7C" -}}
+					{{- .Value | urlquery -}}
+					{{- "&" -}}
+			{{- end -}}
+		{{- end -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.new_silence(Data) */ -}}
+{{- /* URL that points to a Grafana Labs page where a silence to all matching */ -}}
+{{- /* alerts can be added */ -}}
+{{- define "dojo.alerts.url.new_silence" -}}
+	{{- "https://paymentsense.grafana.net/alerting/silence/new?" -}}
+		{{- "alertmanager=ALERTMANAGER_NAME&" -}}
+		{{- /* tenant is a mandatory field for all configured alerts, */ -}}
+		{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+		{{- "matcher=tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
+		{{- /* urgency is to become mandatory via CI... */ -}}
+		{{- with .CommonLabels.urgency -}}
+			{{- "matcher=urgency%3D" -}}{{- . | urlquery -}}{{- "&" -}}
+		{{- /* ...until then, we must account for when it is missing. */ -}}
+		{{- else -}}
+			{{- "matcher=urgency!~%5E(high|low)$" -}}{{- "&" -}}
+		{{- end -}}
+		{{- /* Add any other group labels other than the ones already set */ -}}
+		{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
+			{{- range .SortedPairs -}}
+				{{- "matcher=" -}}
+					{{- .Name | urlquery -}}
+					{{- "%3D" -}}
+					{{- .Value | urlquery -}}
+					{{- "&" -}}
+			{{- end -}}
+		{{- end -}}
+{{- end -}}
+
+{{- /* dojo.documentation.links(Data) */ -}}
+{{- /* Docummentation with links to references regarding the notification */ -}}
+{{- define "dojo.documentation.links" -}}
+	{{- "Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" -}}
+	{{- "\n" -}}
+	{{- "Currently firing alerts for this incident:\n" -}}
+	{{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
+	{{- "\n" -}}
+	{{- "History of alerts for this incident:\n" -}}
+	{{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
+	{{- "\n" -}}
+	{{- "Create new silence to all alerts from this incident:\n" -}}
+	{{ template "dojo.alerts.url.new_silence" . -}}
+{{- end -}}
+
+{{- /* dojo.documentation.high_urgency(Data) */ -}}
+{{- /* Docummentation to be used in notifications for high urgency alerts */ -}}
+{{- define "dojo.documentation.high_urgency" -}}
+	{{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
+	{{- "\n" -}}
+	{{- template "dojo.documentation.links" . -}}
+{{- end -}}
+
+{{- /* dojo.documentation.low_urgency(Data) */ -}}
+{{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
+{{- define "dojo.documentation.low_urgency" -}}
+	{{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
+	{{- "\n" -}}
+	{{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
+	{{- "\n" -}}
+	{{- template "dojo.documentation.links" . -}}
+{{- end -}}
+
+{{- /* dojo.documentation.unknown_urgency(Data) */ -}}
+{{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
+{{- define "dojo.documentation.unknown_urgency" -}}
+	{{- "An alert without a label urgency set to either high or low fired. The worst is assumed here: that the alert is of high urgency.\n" -}}
+	{{- "\n" -}}
+	{{- "This only happens when a misconfiguration happened on this alert, so it needs fixing. There are two actions required.\n" -}}
+	{{- "\n" -}}
+	{{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
+	{{- "\n" -}}
+	{{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
+	{{- "\n" -}}
+	{{- template "dojo.documentation.links" . -}}
+{{- end -}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -887,7 +887,7 @@ func TestDojoTemplates(t *testing.T) {
 					"urgency":   "high",
 				},
 			},
-			exp: "exp",
+			exp: "https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DataSource&var-tenant=example&var-urgency=high&var-alertname=AlertName&var-label=key1%7C%3D%7Cvalue+%241&var-label=key2%7C%3D%7Cvalue+%242&",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -582,6 +582,9 @@ func TestDojoTemplates(t *testing.T) {
 {{- /* dojo.documentation.links(Data) */ -}}
 {{- /* Docummentation with links to references regarding the notification */ -}}
 {{- define "dojo.documentation.links" -}}
+	{{- "Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" -}}
+	{{- "\n" -}}
+	{{- "Currently firing alerts for this incident:\n" -}}
 	{{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
 	{{- "\n" -}}
 	{{- "History of alerts for this incident:\n" -}}
@@ -591,17 +594,19 @@ func TestDojoTemplates(t *testing.T) {
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for high urgency alerts */ -}}
 {{- define "dojo.documentation.high_urgency" -}}
-	{{- "One or more alerts without correct urgency defined have fired. This indicates that there was a misconfiguration on this alert that needs fixing.\n" -}}
+	{{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
 	{{- "\n" -}}
-	{{- "The worst is assumed here: that the alert is of high urgency.\n" -}}
+	{{- template "dojo.documentation.links" . -}}
+{{- end -}}
+
+
+{{- /* dojo.documentation.low_urgency(Data) */ -}}
+{{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
+{{- define "dojo.documentation.low_urgency" -}}
+	{{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
 	{{- "\n" -}}
-	{{- "There are two actions required.\n" -}}
+	{{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
 	{{- "\n" -}}
-	{{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
-	{{- "\n" -}}
-	{{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
-	{{- "\n" -}}
-	{{- "Currently firing alerts for this incident:\n" -}}
 	{{- template "dojo.documentation.links" . -}}
 {{- end -}}
 `
@@ -1000,21 +1005,41 @@ func TestDojoTemplates(t *testing.T) {
 					"urgency": "high",
 				},
 			},
-			exp: "One or more alerts without correct urgency defined have fired. This indicates that there was a misconfiguration on this alert that needs fixing.\n" +
+			exp: "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" +
 				"\n" +
-				"The worst is assumed here: that the alert is of high urgency.\n" +
-				"\n" +
-				"There are two actions required.\n" +
-				"\n" +
-				"The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" +
-				"\n" +
-				"The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" +
+				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
 				"\n" +
 				"Currently firing alerts for this incident:\n" +
 				"https://paymentsense.grafana.net/alerting/list?dataSource=DataSource&queryString=tenant%3Dexample,urgency%3Dhigh,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
 				"\n" +
 				"History of alerts for this incident:\n" +
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DataSource&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
+		},
+		// dojo.documentation.low_urgency
+		{
+			title: "dojo.documentation.low_urgency",
+			in:    `{{ template "dojo.documentation.low_urgency" . }}`,
+			data: Data{
+				GroupLabels: KV{
+					"label1": "value $1",
+					"label2": "value $2",
+				},
+				CommonLabels: KV{
+					"tenant":  "example",
+					"urgency": "low",
+				},
+			},
+			exp: "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" +
+				"\n" +
+				"If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" +
+				"\n" +
+				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
+				"\n" +
+				"Currently firing alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/alerting/list?dataSource=DataSource&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
+				"\n" +
+				"History of alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DataSource&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -616,7 +616,10 @@ func TestDojoTemplates(t *testing.T) {
 	{{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
 	{{- "\n" -}}
 	{{- "History of alerts for this incident:\n" -}}
-	{{ template "dojo.alerts.url.history" . }}
+	{{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
+	{{- "\n" -}}
+	{{- "Create new silence to all alerts from this incident:\n" -}}
+	{{ template "dojo.alerts.url.history" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
@@ -1115,6 +1118,9 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dhigh,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
 				"\n" +
 				"History of alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
+				"\n" +
+				"Create new silence to all alerts from this incident:\n" +
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
 		},
 		// dojo.documentation.low_urgency
@@ -1141,6 +1147,9 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
 				"\n" +
 				"History of alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
+				"\n" +
+				"Create new silence to all alerts from this incident:\n" +
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
 		},
 		// dojo.documentation.unknown_urgency
@@ -1171,6 +1180,9 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
 				"\n" +
 				"History of alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
+				"\n" +
+				"Create new silence to all alerts from this incident:\n" +
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
 		},
 	} {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -544,6 +544,8 @@ func TestDojoTemplates(t *testing.T) {
 		{{- "&alertState=firing" -}}
 {{- end -}}
 
+{{- /* dojo.alerts.url.history(Alerts) */ -}}
+{{- /* URL that points to a Grafana Labs Dashboard with the history of alerts */ -}}
 {{- define "dojo.alerts.url.history" -}}
 	{{- "https://paymentsense.grafana.net/d/luyBQ9Y7z/?" -}}
 		{{- "orgId=1&" -}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -599,13 +599,26 @@ func TestDojoTemplates(t *testing.T) {
 	{{- template "dojo.documentation.links" . -}}
 {{- end -}}
 
-
 {{- /* dojo.documentation.low_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
 {{- define "dojo.documentation.low_urgency" -}}
 	{{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
 	{{- "\n" -}}
 	{{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
+	{{- "\n" -}}
+	{{- template "dojo.documentation.links" . -}}
+{{- end -}}
+
+{{- /* dojo.documentation.unknown_urgency(Data) */ -}}
+{{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
+{{- define "dojo.documentation.unknown_urgency" -}}
+	{{- "An alert without a label urgency set to either high or low fired. The worst is assumed here: that the alert is of high urgency.\n" -}}
+	{{- "\n" -}}
+	{{- "This only happens when a misconfiguration happened on this alert, so it needs fixing. There are two actions required.\n" -}}
+	{{- "\n" -}}
+	{{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
+	{{- "\n" -}}
+	{{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
 	{{- "\n" -}}
 	{{- template "dojo.documentation.links" . -}}
 {{- end -}}
@@ -1032,6 +1045,36 @@ func TestDojoTemplates(t *testing.T) {
 			exp: "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" +
 				"\n" +
 				"If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" +
+				"\n" +
+				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
+				"\n" +
+				"Currently firing alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/alerting/list?dataSource=DataSource&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
+				"\n" +
+				"History of alerts for this incident:\n" +
+				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DataSource&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
+		},
+		// dojo.documentation.unknown_urgency
+		{
+			title: "dojo.documentation.unknown_urgency",
+			in:    `{{ template "dojo.documentation.unknown_urgency" . }}`,
+			data: Data{
+				GroupLabels: KV{
+					"label1": "value $1",
+					"label2": "value $2",
+				},
+				CommonLabels: KV{
+					"tenant":  "example",
+					"urgency": "low",
+				},
+			},
+			exp: "An alert without a label urgency set to either high or low fired. The worst is assumed here: that the alert is of high urgency.\n" +
+				"\n" +
+				"This only happens when a misconfiguration happened on this alert, so it needs fixing. There are two actions required.\n" +
+				"\n" +
+				"The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" +
+				"\n" +
+				"The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" +
 				"\n" +
 				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
 				"\n" +

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -619,7 +619,7 @@ func TestDojoTemplates(t *testing.T) {
 	{{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
 	{{- "\n" -}}
 	{{- "Create new silence to all alerts from this incident:\n" -}}
-	{{ template "dojo.alerts.url.history" . -}}
+	{{ template "dojo.alerts.url.new_silence" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
@@ -1121,7 +1121,7 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
 				"\n" +
 				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
+				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dhigh&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
 		},
 		// dojo.documentation.low_urgency
 		{
@@ -1150,7 +1150,7 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
 				"\n" +
 				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
+				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dlow&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
 		},
 		// dojo.documentation.unknown_urgency
 		{
@@ -1183,7 +1183,7 @@ func TestDojoTemplates(t *testing.T) {
 				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
 				"\n" +
 				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&",
+				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dlow&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
These templates aim to:

- Address issues with default ones from AlertManager.
- Add useful Dojo specific things.

When templates break, we don't notify... so we piggy back on alertmanager's internal unit testing to add test coverage to these templates. On the pro side, we have tests. On the con side, we have to copy / paste them from here to alertops later on... (can be improved with a git submodule for alertmanager at alertops eventually...).

Below is some context to aid review on the goals we have.

# Subject

AlertManager uses [`group_by`](https://prometheus.io/docs/alerting/latest/configuration/#route) to group alerts BEFORE sending a notification. This mean that, once a notification goes to PagerDuty, Slack etc, in the general case, we have a LIST of alerts.

The [template](https://prometheus.io/docs/alerting/latest/notifications/) then, has some inputs that are shaped as a function of `group_by` and which alerts fired.

`GroupLabels`, is **empty** when `group_by` is unset (meaning group **all** alerts), and when `group_by` is set, it contains these label names. This is the "primary key" for the notification essentially.

`CommonLabels` is a function of `Alerts`, and as alerts are grouped, this means that **it constantly changes as alerts open / close**. We can **not** rely on it as primary key. On alertops side though, we enforce the label `tenant` (and will soon enforce `urgency` / `severity`), so these enforced labels are guaranteed to exist at `CommonLabels`, even if not part of `GroupLabels`.

The goal of `dojo.alerts.status_grouped_text` is to provide a "primary key" for the group of alerts, as this is used to define the incident at PagerDuty and inform oncalls about what this is.

# Links

The provided links are also a function of this "primary key", and they point to alert state page, dashboard and silence.

These URLs must be crafted as a function of the alert group "primary key" as well:

- Always contain the `tenant`.
- Contain the `urgency` when it exists.
- Contain an "unknow urgency" filter (though once we enforce urgency, this can be removed).
- Contain any defined `GroupLabels`.

# Documentation

The documentation templates should work for all tenants & urgencies, as these are 100% generic instructions. Alert specific documentation can be found by following the "firing alerts" link.