### PR TITLE
Add slack templates

### DIFF
--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -215,22 +215,22 @@
 {{- /* dojo.documentation.links(Data) */ -}}
 {{- /* Docummentation with links to references regarding the notification */ -}}
 {{- define "dojo.documentation.links" -}}
-    {{- "Below are links referring to all grouped alerts. You must work until all of them are resolved.\n" -}}
-    {{- "\n" -}}
-    {{- "Currently firing alerts for this incident:\n" -}}
+    {{- "Alert Rules:\n" -}}
     {{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
     {{- "\n" -}}
-    {{- "History of alerts for this incident:\n" -}}
+    {{- "Alert History Dashboard:\n" -}}
     {{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
     {{- "\n" -}}
-    {{- "Create new silence to all alerts from this incident:\n" -}}
+    {{- "Silence Alerts:\n" -}}
     {{ template "dojo.alerts.url.new_silence" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for high urgency alerts */ -}}
 {{- define "dojo.documentation.high_urgency" -}}
-    {{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!" -}}
+    {{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
+    {{- "\n" -}}
+    {{- "You must work until all firing alerts are resolved." -}}
 {{- end -}}
 
 {{- /* dojo.documentation.low_urgency(Data) */ -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -236,9 +236,9 @@
 {{- /* dojo.documentation.low_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
 {{- define "dojo.documentation.low_urgency" -}}
-    {{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
+    {{- "Alert(s) fired indicating there's tolerable business impact or that action needs to be taken to prevent issues. They can be worked on the next business day.\n" -}}
     {{- "\n" -}}
-    {{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard." -}}
+    {{- "If this is a misfire, then fix the alert so that it only triggers when action is required." -}}
 {{- end -}}
 
 {{- /* dojo.documentation.unknown_urgency(Data) */ -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -257,7 +257,17 @@
 {{- /* Emoji for Slack notifications. */ -}}
 {{- define "dojo.slack.icon_emoji" -}}
     {{- if eq .Status "firing" -}}
-        {{ ":boom:" }}
+        {{- with .CommonLabels.urgency -}}
+            {{- if eq . "high" -}}
+                {{- ":boom:" -}}
+            {{- else if eq . "low" -}}
+                {{- ":warning:" -}}
+            {{- else -}}
+                {{- ":shit:" -}}
+            {{- end -}}
+        {{- else -}}
+            {{- ":shit:" -}}
+        {{- end -}}
     {{- else -}}
         {{ ":ok_hand:" }}
     {{- end -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -215,7 +215,7 @@
 {{- /* dojo.documentation.links(Data) */ -}}
 {{- /* Docummentation with links to references regarding the notification */ -}}
 {{- define "dojo.documentation.links" -}}
-    {{- "Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" -}}
+    {{- "Below are links referring to all grouped alerts. You must work until all of them are resolved.\n" -}}
     {{- "\n" -}}
     {{- "Currently firing alerts for this incident:\n" -}}
     {{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
@@ -230,9 +230,7 @@
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for high urgency alerts */ -}}
 {{- define "dojo.documentation.high_urgency" -}}
-    {{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
-    {{- "\n" -}}
-    {{- template "dojo.documentation.links" . -}}
+    {{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!" -}}
 {{- end -}}
 
 {{- /* dojo.documentation.low_urgency(Data) */ -}}
@@ -240,9 +238,7 @@
 {{- define "dojo.documentation.low_urgency" -}}
     {{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
     {{- "\n" -}}
-    {{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
-    {{- "\n" -}}
-    {{- template "dojo.documentation.links" . -}}
+    {{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard." -}}
 {{- end -}}
 
 {{- /* dojo.documentation.unknown_urgency(Data) */ -}}
@@ -254,9 +250,7 @@
     {{- "\n" -}}
     {{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
     {{- "\n" -}}
-    {{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
-    {{- "\n" -}}
-    {{- template "dojo.documentation.links" . -}}
+    {{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time." -}}
 {{- end -}}
 
 {{- /* dojo.slack.icon_emoji(Data) */ -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -13,32 +13,32 @@
 {{- /* "[$alertname_value] ($group_label_key=$group_label_value)" */ -}}
 {{- /* "($group_label_key=$group_label_value)" */ -}}
 {{- define "dojo.subject.stable_text" -}}
-	{{- if eq .Status "resolved" -}}
-		{{- "Resolved: " -}}
-	{{- end -}}
-	{{- with .GroupLabels -}}
-		{{- $groupLabels := . -}}
-		{{- with index . "alertname" -}}
-			{{- "[" }}{{ . }}{{ "]" -}}
-		{{- end -}}
-		{{- with .Remove (stringSlice "alertname") -}}
-			{{- with index $groupLabels "alertname" -}}
-				{{- " " -}}
-			{{- end -}}
-			{{ "(" }}
-			{{- with index .SortedPairs 0 -}}
-				{{- .Name }}={{ .Value -}}
-			{{- end -}}
-			{{- with slice .SortedPairs 1 -}}
-				{{- range . -}}
-					{{- " " }}{{ .Name }}={{ .Value -}}
-				{{- end -}}
-			{{- end -}}
-			{{ ")" }}
-		{{- end -}}
-	{{- else -}}
-		{{- "Alerts for " -}}{{- .Receiver -}}
-	{{- end -}}
+    {{- if eq .Status "resolved" -}}
+        {{- "Resolved: " -}}
+    {{- end -}}
+    {{- with .GroupLabels -}}
+        {{- $groupLabels := . -}}
+        {{- with index . "alertname" -}}
+            {{- "[" }}{{ . }}{{ "]" -}}
+        {{- end -}}
+        {{- with .Remove (stringSlice "alertname") -}}
+            {{- with index $groupLabels "alertname" -}}
+                {{- " " -}}
+            {{- end -}}
+            {{ "(" }}
+            {{- with index .SortedPairs 0 -}}
+                {{- .Name }}={{ .Value -}}
+            {{- end -}}
+            {{- with slice .SortedPairs 1 -}}
+                {{- range . -}}
+                    {{- " " }}{{ .Name }}={{ .Value -}}
+                {{- end -}}
+            {{- end -}}
+            {{ ")" }}
+        {{- end -}}
+    {{- else -}}
+        {{- "Alerts for " -}}{{- .Receiver -}}
+    {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alert.text(Alert) */ -}}
@@ -48,40 +48,40 @@
 {{- /*   - "($label=$value)" when "alertname" is missing. */ -}}
 {{- /* - Annotations */ -}}
 {{- define "dojo.alert.text" -}}
-	{{- $alert := . -}}
-	{{- with index .Labels.alertname -}}
-		{{- "[" -}}{{ . }}{{- "]" -}}
-		{{- with ($alert.Labels.Remove (stringSlice "alertname")).SortedPairs -}}
-			{{- " (" }}
-			{{- with index . 0 -}}
-				{{- .Name }}={{ .Value -}}
-			{{- end -}}
-			{{- range slice . 1 -}}
-				{{- " " }}{{ .Name }}={{ .Value -}}
-			{{- end -}}
-			{{- ")" }}
-		{{- end -}}
-	{{- else -}}
-		{{- "(" -}}
-			{{- with index $alert.Labels.SortedPairs 0 -}}
-				{{- .Name }}={{ .Value -}}
-			{{- end -}}
-			{{- with slice $alert.Labels.SortedPairs 1 -}}
-				{{- range . -}}
-					{{- " " }}{{ .Name }}={{ .Value -}}
-				{{- end -}}
-			{{- end -}}
-		{{- ")" -}}
-	{{- end -}}
-	{{- with .Annotations.SortedPairs -}}
-		{{- "\nAnnotations:" -}}
-		{{- range . -}}
-			{{ "\n" }}{{ .Name }}: {{ .Value }}
-		{{- end -}}
-	{{- end -}}
-	{{- with .GeneratorURL -}}
-		{{ "\n" }}{{ . }}
-	{{- end -}}
+    {{- $alert := . -}}
+    {{- with index .Labels.alertname -}}
+        {{- "[" -}}{{ . }}{{- "]" -}}
+        {{- with ($alert.Labels.Remove (stringSlice "alertname")).SortedPairs -}}
+            {{- " (" }}
+            {{- with index . 0 -}}
+                {{- .Name }}={{ .Value -}}
+            {{- end -}}
+            {{- range slice . 1 -}}
+                {{- " " }}{{ .Name }}={{ .Value -}}
+            {{- end -}}
+            {{- ")" }}
+        {{- end -}}
+    {{- else -}}
+        {{- "(" -}}
+            {{- with index $alert.Labels.SortedPairs 0 -}}
+                {{- .Name }}={{ .Value -}}
+            {{- end -}}
+            {{- with slice $alert.Labels.SortedPairs 1 -}}
+                {{- range . -}}
+                    {{- " " }}{{ .Name }}={{ .Value -}}
+                {{- end -}}
+            {{- end -}}
+        {{- ")" -}}
+    {{- end -}}
+    {{- with .Annotations.SortedPairs -}}
+        {{- "\nAnnotations:" -}}
+        {{- range . -}}
+            {{ "\n" }}{{ .Name }}: {{ .Value }}
+        {{- end -}}
+    {{- end -}}
+    {{- with .GeneratorURL -}}
+        {{ "\n" }}{{ . }}
+    {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alerts.text(Alerts) */ -}}
@@ -89,17 +89,17 @@
 {{- /* See also: dojo.alert.text */ -}}
 {{- /* See also: dojo.alerts.status_grouped_text */ -}}
 {{- define "dojo.alerts.text" -}}
-	{{- with . -}}
-		{{- with index . 0 -}}
-			{{- template "dojo.alert.text" . -}}
-		{{- end -}}
-		{{- with slice . 1 -}}
-			{{- range . -}}
-				{{- "\n\n" }}
-				{{- template "dojo.alert.text" . -}}
-			{{- end -}}
-		{{- end -}}
-	{{- end -}}
+    {{- with . -}}
+        {{- with index . 0 -}}
+            {{- template "dojo.alert.text" . -}}
+        {{- end -}}
+        {{- with slice . 1 -}}
+            {{- range . -}}
+                {{- "\n\n" }}
+                {{- template "dojo.alert.text" . -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alerts.status_grouped_text(Alerts) */ -}}
@@ -108,153 +108,195 @@
 {{- /* See also: dojo.alert.text */ -}}
 {{- /* See also: dojo.alerts.text */ -}}
 {{- define "dojo.alerts.status_grouped_text" -}}
-	{{- if and (gt (len .Firing) 0) (gt (len .Resolved) 0)  }}
-		{{- $alerts := . -}}
-		{{- with .Firing -}}
-			{{- "FIRING:\n\n" -}}
-			{{- template "dojo.alerts.text" . -}}
-		{{- end -}}
-		{{- with .Resolved -}}
-			{{- with $alerts.Firing -}}
-				{{- "\n\n" -}}
-			{{- end -}}
-			{{- "RESOLVED:\n\n" -}}
-			{{- template "dojo.alerts.text" . -}}
-		{{- end -}}
-	{{- else -}}
-		{{- template "dojo.alerts.text" .Firing -}}
-		{{- template "dojo.alerts.text" .Resolved -}}
-	{{- end -}}
+    {{- if and (gt (len .Firing) 0) (gt (len .Resolved) 0)  }}
+        {{- $alerts := . -}}
+        {{- with .Firing -}}
+            {{- "FIRING:\n\n" -}}
+            {{- template "dojo.alerts.text" . -}}
+        {{- end -}}
+        {{- with .Resolved -}}
+            {{- with $alerts.Firing -}}
+                {{- "\n\n" -}}
+            {{- end -}}
+            {{- "RESOLVED:\n\n" -}}
+            {{- template "dojo.alerts.text" . -}}
+        {{- end -}}
+    {{- else -}}
+        {{- template "dojo.alerts.text" .Firing -}}
+        {{- template "dojo.alerts.text" .Resolved -}}
+    {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alerts.url.firing(Data) */ -}}
 {{- /* URL that points to Grafana Labs list of firing alerts. */ -}}
 {{- define "dojo.alerts.url.firing" -}}
-	{{- "https://paymentsense.grafana.net/alerting/list?" }}
-		{{- "dataSource=DATASOURCE_NAME" -}}
-		{{- "&queryString=" -}}
-			{{- /* tenant is a mandatory field for all configured alerts, */ -}}
-			{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
-			{{- "tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "," -}}
-			{{- /* urgency is to become mandatory via CI... */ -}}
-			{{- with .CommonLabels.urgency -}}
-				{{- "urgency%3D" -}}{{- . | urlquery -}}{{- "," -}}
-			{{- /* ...until then, we must account for when it is missing. */ -}}
-			{{- else -}}
-				{{- "urgency!~%5E(high%7Clow)$," -}}
-			{{- end -}}
-			{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
-				{{- range .SortedPairs -}}
-					{{- .Name | urlquery -}}{{- "%3D" -}}{{- .Value | urlquery -}}{{- "," -}}
-				{{- end -}}
-			{{- end -}}
-		{{- "&ruleType=alerting" -}}
-		{{- "&alertState=firing" -}}
+    {{- "https://paymentsense.grafana.net/alerting/list?" }}
+        {{- "dataSource=DATASOURCE_NAME" -}}
+        {{- "&queryString=" -}}
+            {{- /* tenant is a mandatory field for all configured alerts, */ -}}
+            {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+            {{- "tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "," -}}
+            {{- /* urgency is to become mandatory via CI... */ -}}
+            {{- with .CommonLabels.urgency -}}
+                {{- "urgency%3D" -}}{{- . | urlquery -}}{{- "," -}}
+            {{- /* ...until then, we must account for when it is missing. */ -}}
+            {{- else -}}
+                {{- "urgency!~%5E(high%7Clow)$," -}}
+            {{- end -}}
+            {{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
+                {{- range .SortedPairs -}}
+                    {{- .Name | urlquery -}}{{- "%3D" -}}{{- .Value | urlquery -}}{{- "," -}}
+                {{- end -}}
+            {{- end -}}
+        {{- "&ruleType=alerting" -}}
+        {{- "&alertState=firing" -}}
 {{- end -}}
 
 {{- /* dojo.alerts.url.history(Data) */ -}}
 {{- /* URL that points to a Grafana Labs Dashboard with the history of alerts */ -}}
 {{- define "dojo.alerts.url.history" -}}
-	{{- "https://paymentsense.grafana.net/d/luyBQ9Y7z/?" -}}
-		{{- "orgId=1&" -}}
-		{{- "var-data_source=DATASOURCE_NAME&" -}}
-		{{- /* tenant is a mandatory field for all configured alerts, */ -}}
-		{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
-		{{- "var-tenant=" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
-		{{- /* urgency is to become mandatory via CI... */ -}}
-		{{- with .CommonLabels.urgency -}}
-			{{- "var-urgency=" -}}{{- . | urlquery -}}{{- "&" -}}
-		{{- /* ...until then, we must account for when it is missing. */ -}}
-		{{- else -}}
-			{{- "var-label=urgency%7C!~%7C%5E(high__gfp__low)$" -}}{{- "&" -}}
-		{{- end -}}
-		{{- /* alertname MAY be part of grouped labels */ -}}
-		{{- with .GroupLabels.alertname -}}
-			{{- "var-alertname=" -}}{{- . | urlquery -}}{{- "&" -}}
-		{{- end -}}
-		{{- /* Add any other group labels other than the ones already set */ -}}
-		{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency" "alertname") -}}
-			{{- range .SortedPairs -}}
-				{{- "var-label=" -}}
-					{{- .Name | urlquery -}}
-					{{- "%7C%3D%7C" -}}
-					{{- .Value | urlquery -}}
-					{{- "&" -}}
-			{{- end -}}
-		{{- end -}}
+    {{- "https://paymentsense.grafana.net/d/luyBQ9Y7z/?" -}}
+        {{- "orgId=1&" -}}
+        {{- "var-data_source=DATASOURCE_NAME&" -}}
+        {{- /* tenant is a mandatory field for all configured alerts, */ -}}
+        {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+        {{- "var-tenant=" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
+        {{- /* urgency is to become mandatory via CI... */ -}}
+        {{- with .CommonLabels.urgency -}}
+            {{- "var-urgency=" -}}{{- . | urlquery -}}{{- "&" -}}
+        {{- /* ...until then, we must account for when it is missing. */ -}}
+        {{- else -}}
+            {{- "var-label=urgency%7C!~%7C%5E(high__gfp__low)$" -}}{{- "&" -}}
+        {{- end -}}
+        {{- /* alertname MAY be part of grouped labels */ -}}
+        {{- with .GroupLabels.alertname -}}
+            {{- "var-alertname=" -}}{{- . | urlquery -}}{{- "&" -}}
+        {{- end -}}
+        {{- /* Add any other group labels other than the ones already set */ -}}
+        {{- with .GroupLabels.Remove (stringSlice "tenant" "urgency" "alertname") -}}
+            {{- range .SortedPairs -}}
+                {{- "var-label=" -}}
+                    {{- .Name | urlquery -}}
+                    {{- "%7C%3D%7C" -}}
+                    {{- .Value | urlquery -}}
+                    {{- "&" -}}
+            {{- end -}}
+        {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alerts.url.new_silence(Data) */ -}}
 {{- /* URL that points to a Grafana Labs page where a silence to all matching */ -}}
 {{- /* alerts can be added */ -}}
 {{- define "dojo.alerts.url.new_silence" -}}
-	{{- "https://paymentsense.grafana.net/alerting/silence/new?" -}}
-		{{- "alertmanager=ALERTMANAGER_NAME&" -}}
-		{{- /* tenant is a mandatory field for all configured alerts, */ -}}
-		{{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
-		{{- "matcher=tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
-		{{- /* urgency is to become mandatory via CI... */ -}}
-		{{- with .CommonLabels.urgency -}}
-			{{- "matcher=urgency%3D" -}}{{- . | urlquery -}}{{- "&" -}}
-		{{- /* ...until then, we must account for when it is missing. */ -}}
-		{{- else -}}
-			{{- "matcher=urgency!~%5E(high|low)$" -}}{{- "&" -}}
-		{{- end -}}
-		{{- /* Add any other group labels other than the ones already set */ -}}
-		{{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
-			{{- range .SortedPairs -}}
-				{{- "matcher=" -}}
-					{{- .Name | urlquery -}}
-					{{- "%3D" -}}
-					{{- .Value | urlquery -}}
-					{{- "&" -}}
-			{{- end -}}
-		{{- end -}}
+    {{- "https://paymentsense.grafana.net/alerting/silence/new?" -}}
+        {{- "alertmanager=ALERTMANAGER_NAME&" -}}
+        {{- /* tenant is a mandatory field for all configured alerts, */ -}}
+        {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+        {{- "matcher=tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
+        {{- /* urgency is to become mandatory via CI... */ -}}
+        {{- with .CommonLabels.urgency -}}
+            {{- "matcher=urgency%3D" -}}{{- . | urlquery -}}{{- "&" -}}
+        {{- /* ...until then, we must account for when it is missing. */ -}}
+        {{- else -}}
+            {{- "matcher=urgency!~%5E(high|low)$" -}}{{- "&" -}}
+        {{- end -}}
+        {{- /* Add any other group labels other than the ones already set */ -}}
+        {{- with .GroupLabels.Remove (stringSlice "tenant" "urgency") -}}
+            {{- range .SortedPairs -}}
+                {{- "matcher=" -}}
+                    {{- .Name | urlquery -}}
+                    {{- "%3D" -}}
+                    {{- .Value | urlquery -}}
+                    {{- "&" -}}
+            {{- end -}}
+        {{- end -}}
 {{- end -}}
 
 {{- /* dojo.documentation.links(Data) */ -}}
 {{- /* Docummentation with links to references regarding the notification */ -}}
 {{- define "dojo.documentation.links" -}}
-	{{- "Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" -}}
-	{{- "\n" -}}
-	{{- "Currently firing alerts for this incident:\n" -}}
-	{{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
-	{{- "\n" -}}
-	{{- "History of alerts for this incident:\n" -}}
-	{{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
-	{{- "\n" -}}
-	{{- "Create new silence to all alerts from this incident:\n" -}}
-	{{ template "dojo.alerts.url.new_silence" . -}}
+    {{- "Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" -}}
+    {{- "\n" -}}
+    {{- "Currently firing alerts for this incident:\n" -}}
+    {{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
+    {{- "\n" -}}
+    {{- "History of alerts for this incident:\n" -}}
+    {{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
+    {{- "\n" -}}
+    {{- "Create new silence to all alerts from this incident:\n" -}}
+    {{ template "dojo.alerts.url.new_silence" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.high_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for high urgency alerts */ -}}
 {{- define "dojo.documentation.high_urgency" -}}
-	{{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
-	{{- "\n" -}}
-	{{- template "dojo.documentation.links" . -}}
+    {{- "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" -}}
+    {{- "\n" -}}
+    {{- template "dojo.documentation.links" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.low_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
 {{- define "dojo.documentation.low_urgency" -}}
-	{{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
-	{{- "\n" -}}
-	{{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
-	{{- "\n" -}}
-	{{- template "dojo.documentation.links" . -}}
+    {{- "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" -}}
+    {{- "\n" -}}
+    {{- "If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" -}}
+    {{- "\n" -}}
+    {{- template "dojo.documentation.links" . -}}
 {{- end -}}
 
 {{- /* dojo.documentation.unknown_urgency(Data) */ -}}
 {{- /* Docummentation to be used in notifications for low urgency alerts */ -}}
 {{- define "dojo.documentation.unknown_urgency" -}}
-	{{- "An alert without a label urgency set to either high or low fired. The worst is assumed here: that the alert is of high urgency.\n" -}}
-	{{- "\n" -}}
-	{{- "This only happens when a misconfiguration happened on this alert, so it needs fixing. There are two actions required.\n" -}}
-	{{- "\n" -}}
-	{{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
-	{{- "\n" -}}
-	{{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
-	{{- "\n" -}}
-	{{- template "dojo.documentation.links" . -}}
+    {{- "An alert without a label urgency set to either high or low fired. The worst is assumed here: that the alert is of high urgency.\n" -}}
+    {{- "\n" -}}
+    {{- "This only happens when a misconfiguration happened on this alert, so it needs fixing. There are two actions required.\n" -}}
+    {{- "\n" -}}
+    {{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
+    {{- "\n" -}}
+    {{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" -}}
+    {{- "\n" -}}
+    {{- template "dojo.documentation.links" . -}}
+{{- end -}}
+
+{{- /* dojo.slack.icon_emoji(Data) */ -}}
+{{- /* Emoji for Slack notifications. */ -}}
+{{- define "dojo.slack.icon_emoji" -}}
+    {{- if eq .Status "firing" -}}
+        {{ ":boom:" }}
+    {{- else -}}
+        {{ ":ok_hand:" }}
+    {{- end -}}
+{{- end -}}
+
+{{- /* dojo.slack.fallback(Data) */ -}}
+{{- /* Fallback for Slack notifications. */ -}}
+{{- define "dojo.slack.fallback" -}}
+    {{- template "dojo.subject.stable_text" . -}}
+    {{- " | " -}}
+    {{- template "dojo.alerts.url.firing" . -}}
+{{- end -}}
+
+{{- /* dojo.slack.color(Data) */ -}}
+{{- /* Color Slack notifications: */ -}}
+{{- /* - High urgency: red. */ -}}
+{{- /* - Low urgency: yellow. */ -}}
+{{- /* - Unknown urgency: red. */ -}}
+{{- /* - Resolved: green. */ -}}
+{{ define "dojo.slack.color" -}}
+    {{- if eq .Status "firing" -}}
+        {{- with .CommonLabels.urgency -}}
+            {{- if eq . "high" -}}
+                {{- "danger" -}}
+            {{- else if eq . "low" -}}
+                {{- "warning" -}}
+            {{- else -}}
+                {{- "danger" -}}
+            {{- end -}}
+        {{- else -}}
+            {{- "danger" -}}
+        {{- end -}}
+    {{ else -}}
+        {{- "good" -}}
+    {{- end -}}
 {{- end -}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1131,12 +1131,45 @@ func TestDojoSlack(t *testing.T) {
 		fail bool
 	}{
 		{
-			title: "dojo.slack.icon_emoji with firing alerts",
+			title: "dojo.slack.icon_emoji with firing high urgency alerts",
+			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "high",
+				},
+			},
+			exp: ":boom:",
+		},
+		{
+			title: "dojo.slack.icon_emoji with firing low urgency alerts",
+			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "low",
+				},
+			},
+			exp: ":warning:",
+		},
+		{
+			title: "dojo.slack.icon_emoji with firing bad urgency alerts",
+			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "bad",
+				},
+			},
+			exp: ":shit:",
+		},
+		{
+			title: "dojo.slack.icon_emoji with firing no urgency alerts",
 			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
 			data: Data{
 				Status: "firing",
 			},
-			exp: ":boom:",
+			exp: ":shit:",
 		},
 		{
 			title: "dojo.slack.icon_emoji with non firing alerts",

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1007,7 +1007,9 @@ func TestDojoDocumentationHighUrgency(t *testing.T) {
 					"urgency": "high",
 				},
 			},
-			exp: "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!",
+			exp: "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" +
+				"\n" +
+				"You must work until all firing alerts are resolved.",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1051,9 +1051,9 @@ func TestDojoDocumentationLowUrgency(t *testing.T) {
 					"urgency": "low",
 				},
 			},
-			exp: "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" +
+			exp: "Alert(s) fired indicating there's tolerable business impact or that action needs to be taken to prevent issues. They can be worked on the next business day.\n" +
 				"\n" +
-				"If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.",
+				"If this is a misfire, then fix the alert so that it only triggers when action is required.",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1007,18 +1007,7 @@ func TestDojoDocumentationHighUrgency(t *testing.T) {
 					"urgency": "high",
 				},
 			},
-			exp: "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!\n" +
-				"\n" +
-				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
-				"\n" +
-				"Currently firing alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dhigh,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
-				"\n" +
-				"History of alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=high&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
-				"\n" +
-				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dhigh&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
+			exp: "Alert(s) of high urgency have fired meaning there's likely business impact going on. Please work on fixing the problem IMMEDIATELY!",
 		},
 	} {
 		tc := tc
@@ -1062,18 +1051,7 @@ func TestDojoDocumentationLowUrgency(t *testing.T) {
 			},
 			exp: "Alert(s) of low urgency have fired. They indicate that there's either tolerable business impact or potential business impact if no action is taken within the next business day. Evaluate the firing alerts and take necessary actions to fix / prevent any problems.\n" +
 				"\n" +
-				"If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.\n" +
-				"\n" +
-				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
-				"\n" +
-				"Currently firing alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
-				"\n" +
-				"History of alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
-				"\n" +
-				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dlow&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
+				"If you identify that no action is required, it means the alert misfired, meaning the action to be taken here is to adjust the alert tirggering mechanism so that it only fires when it is actionable. If you find the alert signal useful, despite not being actionable, then the signal can be moved to a dashboard.",
 		},
 	} {
 		tc := tc
@@ -1121,18 +1099,7 @@ func TestDojoDocumentationUnknownUrgency(t *testing.T) {
 				"\n" +
 				"The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" +
 				"\n" +
-				"The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.\n" +
-				"\n" +
-				"Below are links referring to all alerts grouped. You must work until all of them are resolved.\n" +
-				"\n" +
-				"Currently firing alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,label1%3Dvalue+%241,label2%3Dvalue+%242,&ruleType=alerting&alertState=firing\n" +
-				"\n" +
-				"History of alerts for this incident:\n" +
-				"https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&var-data_source=DATASOURCE_NAME&var-tenant=example&var-urgency=low&var-label=label1%7C%3D%7Cvalue+%241&var-label=label2%7C%3D%7Cvalue+%242&\n" +
-				"\n" +
-				"Create new silence to all alerts from this incident:\n" +
-				"https://paymentsense.grafana.net/alerting/silence/new?alertmanager=ALERTMANAGER_NAME&matcher=tenant%3Dexample&matcher=urgency%3Dlow&matcher=label1%3Dvalue+%241&matcher=label2%3Dvalue+%242&",
+				"The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time.",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1148,3 +1148,104 @@ func TestDojoDocumentationUnknownUrgency(t *testing.T) {
 		})
 	}
 }
+
+func TestDojoSlack(t *testing.T) {
+	tmpl, err := FromGlobs()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		title string
+		in    string
+		data  interface{}
+
+		exp  string
+		fail bool
+	}{
+		{
+			title: "dojo.slack.icon_emoji with firing alerts",
+			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
+			data: Data{
+				Status: "firing",
+			},
+			exp: ":boom:",
+		},
+		{
+			title: "dojo.slack.icon_emoji with non firing alerts",
+			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
+			data: Data{
+				Status: "resolved",
+			},
+			exp: ":ok_hand:",
+		},
+		{
+			title: "dojo.slack.fallback",
+			in:    `{{ template "dojo.slack.fallback" . }}`,
+			data: Data{
+				Receiver: "Receiver",
+				Status:   "firing",
+			},
+			exp: "Alerts for Receiver | https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3D,urgency!~%5E(high%7Clow)$,&ruleType=alerting&alertState=firing",
+		},
+		{
+			title: "dojo.slack.color with firing high urgency alerts",
+			in:    `{{ template "dojo.slack.color" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "high",
+				},
+			},
+			exp: "danger",
+		},
+		{
+			title: "dojo.slack.color with firing low urgency alerts",
+			in:    `{{ template "dojo.slack.color" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "low",
+				},
+			},
+			exp: "warning",
+		},
+		{
+			title: "dojo.slack.color with firing bad urgency alerts",
+			in:    `{{ template "dojo.slack.color" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "bad",
+				},
+			},
+			exp: "danger",
+		},
+		{
+			title: "dojo.slack.color with firing no urgency alerts",
+			in:    `{{ template "dojo.slack.color" . }}`,
+			data: Data{
+				Status: "firing",
+			},
+			exp: "danger",
+		},
+		{
+			title: "dojo.slack.color with no firing alerts",
+			in:    `{{ template "dojo.slack.color" . }}`,
+			data: Data{
+				Status: "resolved",
+			},
+			exp: "good",
+		},
+	} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			f := tmpl.ExecuteTextString
+			got, err := f(globalDojoTemplate+tc.in, tc.data)
+			if tc.fail {
+				require.NotNil(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
Ditto.

Also, remove doc links from generic documentation text, so we can reuse the text at Slack (as Slack supports adding a list of links, so it can have shorter text).

There are a bunch of "tabs to space" conversion as well, can all be ignored.