### PR TITLE
Random improvements

### DIFF
--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -37,7 +37,17 @@
             {{ ")" }}
         {{- end -}}
     {{- else -}}
-        {{- "Alerts for " -}}{{- .Receiver -}}
+        {{- /* tenant is a mandatory field for all configured alerts, */ -}}
+        {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
+        {{- .CommonLabels.tenant -}}{{- ": " -}}
+        {{- /* urgency is to become mandatory via CI... */ -}}
+        {{- with .CommonLabels.urgency -}}
+            {{- . -}}
+        {{- /* ...until then, we must account for when it is missing. */ -}}
+        {{- else -}}
+            {{- "unknown" -}}
+        {{- end -}}
+        {{- " urgency alerts firing" -}}
     {{- end -}}
 {{- end -}}
 

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -160,14 +160,14 @@
 {{- define "dojo.alerts.status_title_list" -}}
     {{- $alerts := . -}}
     {{- with .Firing -}}
-        {{- "FIRING:\n\n" -}}
+        {{- "🔥 FIRING:\n\n" -}}
         {{- template "dojo.alerts.title_list" . -}}
     {{- end -}}
     {{- with .Resolved -}}
         {{- with $alerts.Firing -}}
             {{- "\n\n" -}}
         {{- end -}}
-        {{- "RESOLVED:\n\n" -}}
+        {{- "👌 RESOLVED:\n\n" -}}
         {{- template "dojo.alerts.title_list" . -}}
     {{- end -}}
 {{- end -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -71,13 +71,11 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* dojo.alert.text(Alert) */ -}}
-{{- /* Textual representation of the Alert with: */ -}}
-{{- /* - A descriptive "alert name": */ -}}
-{{- /*   - "[$alertname_value] ($label=$value)" when "alertname" label exists. */ -}}
-{{- /*   - "($label=$value)" when "alertname" is missing. */ -}}
-{{- /* - Annotations */ -}}
-{{- define "dojo.alert.text" -}}
+{{- /* dojo.alert.title(Alert) */ -}}
+{{- /* Alert title: */ -}}
+{{- /* - "[$alertname_value] ($label=$value)" when "alertname" label exists. */ -}}
+{{- /* - "($label=$value)" when "alertname" is missing. */ -}}
+{{- define "dojo.alert.title" -}}
     {{- $alert := . -}}
     {{- with index .Labels.alertname -}}
         {{- "[" -}}{{ . }}{{- "]" -}}
@@ -103,6 +101,13 @@
             {{- end -}}
         {{- ")" -}}
     {{- end -}}
+{{- end -}}
+
+{{- /* dojo.alert.text(Alert) */ -}}
+{{- /* Textual representation of the Alert with its labels, annotations and */ -}}
+{{- /* link. */ -}}
+{{- define "dojo.alert.text" -}}
+    {{- template "dojo.alert.title" . -}}
     {{- with .Annotations.SortedPairs -}}
         {{- "\nAnnotations:" -}}
         {{- range . -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -158,6 +158,12 @@
 {{- end -}}
 
 {{- /* dojo.alerts.url.firing(Data) */ -}}
+{{- /* Title for dojo.alerts.url.firing */ -}}
+{{- define "dojo.alerts.url.firing.title" -}}
+    {{- "📜 Alert Rules" -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.firing(Data) */ -}}
 {{- /* URL that points to Grafana Labs list of firing alerts. */ -}}
 {{- define "dojo.alerts.url.firing" -}}
     {{- "https://paymentsense.grafana.net/alerting/list?" }}
@@ -180,6 +186,12 @@
             {{- end -}}
         {{- "&ruleType=alerting" -}}
         {{- "&alertState=firing" -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.history(Data) */ -}}
+{{- /* Title for dojo.alerts.url.history */ -}}
+{{- define "dojo.alerts.url.history.title" -}}
+    {{- "📈 Alert History Dashboard" -}}
 {{- end -}}
 
 {{- /* dojo.alerts.url.history(Data) */ -}}
@@ -215,6 +227,12 @@
 {{- end -}}
 
 {{- /* dojo.alerts.url.new_silence(Data) */ -}}
+{{- /* Title for dojo.alerts.url.new_silence */ -}}
+{{- define "dojo.alerts.url.new_silence.title" -}}
+    {{- "🔕 Silence Alerts" -}}
+{{- end -}}
+
+{{- /* dojo.alerts.url.new_silence(Data) */ -}}
 {{- /* URL that points to a Grafana Labs page where a silence to all matching */ -}}
 {{- /* alerts can be added */ -}}
 {{- define "dojo.alerts.url.new_silence" -}}
@@ -245,13 +263,13 @@
 {{- /* dojo.documentation.links(Data) */ -}}
 {{- /* Docummentation with links to references regarding the notification */ -}}
 {{- define "dojo.documentation.links" -}}
-    {{- "📜 Alert Rules:\n" -}}
+    {{ template "dojo.alerts.url.firing.title" . }}{{- ":\n" -}}
     {{ template "dojo.alerts.url.firing" . }}{{- "\n" -}}
     {{- "\n" -}}
-    {{- "📈 Alert History Dashboard:\n" -}}
+    {{ template "dojo.alerts.url.history.title" . }}{{- ":\n" -}}
     {{ template "dojo.alerts.url.history" . -}}{{- "\n" -}}
     {{- "\n" -}}
-    {{- "🔕 Silence Alerts:\n" -}}
+    {{ template "dojo.alerts.url.new_silence.title" . }}{{- ":\n" -}}
     {{ template "dojo.alerts.url.new_silence" . -}}
 {{- end -}}
 

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -136,9 +136,9 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* dojo.alerts.details(Alerts) */ -}}
+{{- /* dojo.alerts.details_list(Alerts) */ -}}
 {{- /* Textual representation of a list of Alerts. */ -}}
-{{- define "dojo.alerts.details" -}}
+{{- define "dojo.alerts.details_list" -}}
     {{- with . -}}
         {{- with index . 0 -}}
             {{- template "dojo.alert.details" . -}}
@@ -152,28 +152,23 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* dojo.alerts.status_grouped_text(Alerts) */ -}}
+{{- /* dojo.alerts.status_title_list(Alerts) */ -}}
 {{- /* Textual representation of a list of Alerts with status */ -}}
 {{- /* (firing / resolved) grouping. */ -}}
 {{- /* See also: dojo.alert.details */ -}}
 {{- /* See also: dojo.alerts.details */ -}}
-{{- define "dojo.alerts.status_grouped_text" -}}
-    {{- if and (gt (len .Firing) 0) (gt (len .Resolved) 0)  }}
-        {{- $alerts := . -}}
-        {{- with .Firing -}}
-            {{- "FIRING:\n\n" -}}
-            {{- template "dojo.alerts.details" . -}}
+{{- define "dojo.alerts.status_title_list" -}}
+    {{- $alerts := . -}}
+    {{- with .Firing -}}
+        {{- "FIRING:\n\n" -}}
+        {{- template "dojo.alerts.title_list" . -}}
+    {{- end -}}
+    {{- with .Resolved -}}
+        {{- with $alerts.Firing -}}
+            {{- "\n\n" -}}
         {{- end -}}
-        {{- with .Resolved -}}
-            {{- with $alerts.Firing -}}
-                {{- "\n\n" -}}
-            {{- end -}}
-            {{- "RESOLVED:\n\n" -}}
-            {{- template "dojo.alerts.details" . -}}
-        {{- end -}}
-    {{- else -}}
-        {{- template "dojo.alerts.details" .Firing -}}
-        {{- template "dojo.alerts.details" .Resolved -}}
+        {{- "RESOLVED:\n\n" -}}
+        {{- template "dojo.alerts.title_list" . -}}
     {{- end -}}
 {{- end -}}
 

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -108,8 +108,15 @@
 {{- /* dojo.alerts.title_list(Alerts) */ -}}
 {{- /* List of alert titles. */ -}}
 {{- define "dojo.alerts.title_list" -}}
-    {{- range . -}}
-        {{- "- " }}{{- template "dojo.alert.details" . -}}{{- "\n" }}
+    {{- with . -}}
+        {{- with index . 0 -}}
+            {{- "- " }}{{- template "dojo.alert.title" . -}}
+        {{- end -}}
+        {{- with slice . 1 -}}
+            {{- range . -}}
+                {{- "\n- " }}{{- template "dojo.alert.title" . -}}
+            {{- end -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -44,7 +44,7 @@
 {{- /* can change as new alerts fire and old alerts resolve, making the subject */ -}}
 {{- /* value change as well. */ -}}
 {{- /* Having a stable subject is good for use cases where the grouped alerts state */ -}}
-{{- /* is to me synchronised with another system (eg: PagerDuty), and we */ -}}
+{{- /* is to be synchronised with another system (eg: PagerDuty), and we */ -}}
 {{- /* want to prevent a stale subject from misleading people. */ -}}
 {{- /* It also makes use of standard labels tenant and urgency, expected */ -}}
 {{- /* to universally exist. */ -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -1,3 +1,23 @@
+{{- /* dojo.emoji(Data) */ -}}
+{{- /* An emoji as a function of firing alerts and the urgency. */ -}}
+{{- define "dojo.emoji" -}}
+    {{- if eq .Status "firing" -}}
+        {{- with .CommonLabels.urgency -}}
+            {{- if eq . "high" -}}
+                {{- "💥" -}}
+            {{- else if eq . "low" -}}
+                {{- "⚠️" -}}
+            {{- else -}}
+                {{- "💩" -}}
+            {{- end -}}
+        {{- else -}}
+            {{- "💩" -}}
+        {{- end -}}
+    {{- else -}}
+        {{ "👌" }}
+    {{- end -}}
+{{- end -}}
+
 {{- /* dojo.subject.stable_text(Data) */ -}}
 {{- /* This provides a stable subject value that is only a function of the static */ -}}
 {{- /* values used to group the alerts being notified (GroupLabels). */ -}}
@@ -261,26 +281,6 @@
     {{- "The immediate action, is to evaluate the real urgency of the firing alert(s) and work on it accordingly.\n" -}}
     {{- "\n" -}}
     {{- "The secondary action, is to fix the alert configuration so that it fires with a correctly defined urgency next time." -}}
-{{- end -}}
-
-{{- /* dojo.slack.icon_emoji(Data) */ -}}
-{{- /* Emoji for Slack notifications. */ -}}
-{{- define "dojo.slack.icon_emoji" -}}
-    {{- if eq .Status "firing" -}}
-        {{- with .CommonLabels.urgency -}}
-            {{- if eq . "high" -}}
-                {{- ":boom:" -}}
-            {{- else if eq . "low" -}}
-                {{- ":warning:" -}}
-            {{- else -}}
-                {{- ":shit:" -}}
-            {{- end -}}
-        {{- else -}}
-            {{- ":shit:" -}}
-        {{- end -}}
-    {{- else -}}
-        {{ ":ok_hand:" }}
-    {{- end -}}
 {{- end -}}
 
 {{- /* dojo.slack.fallback(Data) */ -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -1,3 +1,21 @@
+{{- /* dojo.grafana.url */ -}}
+{{- /* URL for the grafana instance. */ -}}
+{{- define "dojo.grafana.url" -}}
+    {{- "https://example.grafana.net/" -}}
+{{- end -}}
+
+{{- /* dojo.grafana.alerting.list.data_source */ -}}
+{{- /* Data source for alert list (alerting/list?dataSource=XXX). */ -}}
+{{- define "dojo.grafana.alerting.list.data_source" -}}
+    {{- "DATASOURCE_NAME" -}}
+{{- end -}}
+
+{{- /* dojo.grafana.alerting.alertmanager */ -}}
+{{- /* AlertManager instance (silences?alertmanager=XXX). */ -}}
+{{- define "dojo.grafana.alerting.alertmanager" -}}
+    {{- "ALERTMANAGER_NAME" -}}
+{{- end -}}
+
 {{- /* dojo.emoji(Data) */ -}}
 {{- /* An emoji as a function of firing alerts and the urgency. */ -}}
 {{- define "dojo.emoji" -}}
@@ -181,8 +199,8 @@
 {{- /* dojo.alerts.url.firing(Data) */ -}}
 {{- /* URL that points to Grafana Labs list of firing alerts. */ -}}
 {{- define "dojo.alerts.url.firing" -}}
-    {{- "https://paymentsense.grafana.net/alerting/list?" }}
-        {{- "dataSource=DATASOURCE_NAME" -}}
+    {{- template "dojo.grafana.url" -}}{{- "alerting/list?" }}
+        {{- "dataSource=" -}}{{- template "dojo.grafana.alerting.list.data_source" -}}
         {{- "&queryString=" -}}
             {{- /* tenant is a mandatory field for all configured alerts, */ -}}
             {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
@@ -212,9 +230,9 @@
 {{- /* dojo.alerts.url.history(Data) */ -}}
 {{- /* URL that points to a Grafana Labs Dashboard with the history of alerts */ -}}
 {{- define "dojo.alerts.url.history" -}}
-    {{- "https://paymentsense.grafana.net/d/luyBQ9Y7z/?" -}}
+    {{- template "dojo.grafana.url" -}}{{- "d/luyBQ9Y7z/?" -}}
         {{- "orgId=1&" -}}
-        {{- "var-data_source=DATASOURCE_NAME&" -}}
+        {{- "var-data_source=" -}}{{- template "dojo.grafana.alerting.list.data_source" -}}{{- "&" -}}
         {{- /* tenant is a mandatory field for all configured alerts, */ -}}
         {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
         {{- "var-tenant=" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}
@@ -251,8 +269,8 @@
 {{- /* URL that points to a Grafana Labs page where a silence to all matching */ -}}
 {{- /* alerts can be added */ -}}
 {{- define "dojo.alerts.url.new_silence" -}}
-    {{- "https://paymentsense.grafana.net/alerting/silence/new?" -}}
-        {{- "alertmanager=ALERTMANAGER_NAME&" -}}
+    {{- template "dojo.grafana.url" -}}{{- "alerting/silence/new?" -}}
+        {{- "alertmanager=" -}}{{- template "dojo.grafana.alerting.alertmanager" -}}{{- "&" -}}
         {{- /* tenant is a mandatory field for all configured alerts, */ -}}
         {{- /* validated by CI so it is guaranteed to exist at CommonLabels */ -}}
         {{- "matcher=tenant%3D" -}}{{- .CommonLabels.tenant | urlquery -}}{{- "&" -}}

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -28,6 +28,8 @@
 {{- /* Having a stable subject is good for use cases where the grouped alerts state */ -}}
 {{- /* is to me synchronised with another system (eg: PagerDuty), and we */ -}}
 {{- /* want to prevent a stale subject from misleading people. */ -}}
+{{- /* It also makes use of standard labels tenant and urgency, expected */ -}}
+{{- /* to universally exist. */ -}}
 {{- /* Examples: */ -}}
 {{- /* "Alerts for $receiver" */ -}}
 {{- /* "[$alertname_value] ($group_label_key=$group_label_value)" */ -}}
@@ -103,10 +105,18 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* dojo.alert.text(Alert) */ -}}
+{{- /* dojo.alerts.title_list(Alerts) */ -}}
+{{- /* List of alert titles. */ -}}
+{{- define "dojo.alerts.title_list" -}}
+    {{- range . -}}
+        {{- "- " }}{{- template "dojo.alert.details" . -}}{{- "\n" }}
+    {{- end -}}
+{{- end -}}
+
+{{- /* dojo.alert.details(Alert) */ -}}
 {{- /* Textual representation of the Alert with its labels, annotations and */ -}}
 {{- /* link. */ -}}
-{{- define "dojo.alert.text" -}}
+{{- define "dojo.alert.details" -}}
     {{- template "dojo.alert.title" . -}}
     {{- with .Annotations.SortedPairs -}}
         {{- "\nAnnotations:" -}}
@@ -119,54 +129,44 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* dojo.alerts.text(Alerts) */ -}}
+{{- /* dojo.alerts.details(Alerts) */ -}}
 {{- /* Textual representation of a list of Alerts. */ -}}
-{{- /* See also: dojo.alert.text */ -}}
-{{- /* See also: dojo.alerts.status_grouped_text */ -}}
-{{- define "dojo.alerts.text" -}}
+{{- define "dojo.alerts.details" -}}
     {{- with . -}}
         {{- with index . 0 -}}
-            {{- template "dojo.alert.text" . -}}
+            {{- template "dojo.alert.details" . -}}
         {{- end -}}
         {{- with slice . 1 -}}
             {{- range . -}}
                 {{- "\n\n" }}
-                {{- template "dojo.alert.text" . -}}
+                {{- template "dojo.alert.details" . -}}
             {{- end -}}
         {{- end -}}
-    {{- end -}}
-{{- end -}}
-
-{{- /* dojo.alerts.title_list(Alerts) */ -}}
-{{- /* List of alert titles. */ -}}
-{{- define "dojo.alerts.title_list" -}}
-    {{- range . -}}
-        {{- "- " }}{{- template "dojo.alert.text" . -}}{{- "\n" }}
     {{- end -}}
 {{- end -}}
 
 {{- /* dojo.alerts.status_grouped_text(Alerts) */ -}}
 {{- /* Textual representation of a list of Alerts with status */ -}}
 {{- /* (firing / resolved) grouping. */ -}}
-{{- /* See also: dojo.alert.text */ -}}
-{{- /* See also: dojo.alerts.text */ -}}
+{{- /* See also: dojo.alert.details */ -}}
+{{- /* See also: dojo.alerts.details */ -}}
 {{- define "dojo.alerts.status_grouped_text" -}}
     {{- if and (gt (len .Firing) 0) (gt (len .Resolved) 0)  }}
         {{- $alerts := . -}}
         {{- with .Firing -}}
             {{- "FIRING:\n\n" -}}
-            {{- template "dojo.alerts.text" . -}}
+            {{- template "dojo.alerts.details" . -}}
         {{- end -}}
         {{- with .Resolved -}}
             {{- with $alerts.Firing -}}
                 {{- "\n\n" -}}
             {{- end -}}
             {{- "RESOLVED:\n\n" -}}
-            {{- template "dojo.alerts.text" . -}}
+            {{- template "dojo.alerts.details" . -}}
         {{- end -}}
     {{- else -}}
-        {{- template "dojo.alerts.text" .Firing -}}
-        {{- template "dojo.alerts.text" .Resolved -}}
+        {{- template "dojo.alerts.details" .Firing -}}
+        {{- template "dojo.alerts.details" .Resolved -}}
     {{- end -}}
 {{- end -}}
 

--- a/template/global-dojo.tmpl
+++ b/template/global-dojo.tmpl
@@ -137,6 +137,14 @@
     {{- end -}}
 {{- end -}}
 
+{{- /* dojo.alerts.title_list(Alerts) */ -}}
+{{- /* List of alert titles. */ -}}
+{{- define "dojo.alerts.title_list" -}}
+    {{- range . -}}
+        {{- "- " }}{{- template "dojo.alert.text" . -}}{{- "\n" }}
+    {{- end -}}
+{{- end -}}
+
 {{- /* dojo.alerts.status_grouped_text(Alerts) */ -}}
 {{- /* Textual representation of a list of Alerts with status */ -}}
 {{- /* (firing / resolved) grouping. */ -}}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -410,8 +410,12 @@ func TestDojoSubjectStableText(t *testing.T) {
 			data: Data{
 				Receiver: "Receiver",
 				Status:   "firing",
+				CommonLabels: KV{
+					"tenant":  "example",
+					"urgency": "high",
+				},
 			},
-			exp: "Alerts for Receiver",
+			exp: "example: high urgency alerts firing",
 		},
 		{
 			title: "dojo.subject.stable_text with no group_by and resolved alerts",
@@ -419,8 +423,12 @@ func TestDojoSubjectStableText(t *testing.T) {
 			data: Data{
 				Receiver: "Receiver",
 				Status:   "resolved",
+				CommonLabels: KV{
+					"tenant":  "example",
+					"urgency": "high",
+				},
 			},
-			exp: "Resolved: Alerts for Receiver",
+			exp: "Resolved: example: high urgency alerts firing",
 		},
 		{
 			title: "dojo.subject.stable_text with group_by, alertname and firing alerts",
@@ -1185,8 +1193,12 @@ func TestDojoSlack(t *testing.T) {
 			data: Data{
 				Receiver: "Receiver",
 				Status:   "firing",
+				CommonLabels: KV{
+					"tenant":  "example",
+					"urgency": "low",
+				},
 			},
-			exp: "Alerts for Receiver | https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3D,urgency!~%5E(high%7Clow)$,&ruleType=alerting&alertState=firing",
+			exp: "example: low urgency alerts firing | https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,&ruleType=alerting&alertState=firing",
 		},
 		{
 			title: "dojo.slack.color with firing high urgency alerts",

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -946,11 +946,11 @@ func TestDojoAlertsStatusTitleList(t *testing.T) {
 					},
 				},
 			},
-			exp: "FIRING:\n" +
+			exp: "🔥 FIRING:\n" +
 				"\n" +
 				"- [AlertName1] (label1=value1 label2=value2)\n" +
 				"\n" +
-				"RESOLVED:\n" +
+				"👌 RESOLVED:\n" +
 				"\n" +
 				"- (label1=value1 label2=value2)",
 		},
@@ -978,7 +978,7 @@ func TestDojoAlertsStatusTitleList(t *testing.T) {
 					},
 				},
 			},
-			exp: "FIRING:\n" +
+			exp: "🔥 FIRING:\n" +
 				"\n" +
 				"- [AlertName1] (label1=value1 label2=value2)\n" +
 				"- (label1=value1 label2=value2)",
@@ -1007,7 +1007,7 @@ func TestDojoAlertsStatusTitleList(t *testing.T) {
 					},
 				},
 			},
-			exp: "RESOLVED:\n" +
+			exp: "👌 RESOLVED:\n" +
 				"\n" +
 				"- [AlertName1] (label1=value1 label2=value2)\n" +
 				"- (label1=value1 label2=value2)",

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -660,7 +660,23 @@ func TestDojoAlertsTitleList(t *testing.T) {
 		fail bool
 	}{
 		{
-			title: "dojo.alert.title",
+			title: "dojo.alert.title with single alert",
+			in:    `{{ template "dojo.alerts.title_list" .Alerts }}`,
+			data: Data{
+				Alerts: Alerts{
+					Alert{
+						Labels: KV{
+							"alertname": "AlertName",
+							"label1":    "value1",
+							"label2":    "value2",
+						},
+					},
+				},
+			},
+			exp: "- [AlertName] (label1=value1 label2=value2)",
+		},
+		{
+			title: "dojo.alert.title with multiple alerts",
 			in:    `{{ template "dojo.alerts.title_list" .Alerts }}`,
 			data: Data{
 				Alerts: Alerts{
@@ -679,7 +695,7 @@ func TestDojoAlertsTitleList(t *testing.T) {
 				},
 			},
 			exp: "- [AlertName] (label1=value1 label2=value2)\n" +
-				"- [AlertName]\n",
+				"- [AlertName]",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -814,7 +814,7 @@ func TestDojoAlertDetails(t *testing.T) {
 	}
 }
 
-func TestDojoAlertsDetails(t *testing.T) {
+func TestDojoAlertsDetailsList(t *testing.T) {
 	tmpl, err := FromGlobs()
 	require.NoError(t, err)
 
@@ -827,8 +827,8 @@ func TestDojoAlertsDetails(t *testing.T) {
 		fail bool
 	}{
 		{
-			title: "dojo.alerts.details with one alert",
-			in:    `{{ template "dojo.alerts.details" .Alerts }}`,
+			title: "dojo.alerts.details_list with one alert",
+			in:    `{{ template "dojo.alerts.details_list" .Alerts }}`,
 			data: Data{
 				Alerts: Alerts{
 					Alert{
@@ -853,8 +853,8 @@ func TestDojoAlertsDetails(t *testing.T) {
 				"http://generator.url/",
 		},
 		{
-			title: "dojo.alerts.details with multiple alerts",
-			in:    `{{ template "dojo.alerts.details" .Alerts }}`,
+			title: "dojo.alerts.details_list with multiple alerts",
+			in:    `{{ template "dojo.alerts.details_list" .Alerts }}`,
 			data: Data{
 				Alerts: Alerts{
 					Alert{
@@ -910,7 +910,7 @@ func TestDojoAlertsDetails(t *testing.T) {
 	}
 }
 
-func TestDojoAlertsStatusGroupedText(t *testing.T) {
+func TestDojoAlertsStatusTitleList(t *testing.T) {
 	tmpl, err := FromGlobs()
 	require.NoError(t, err)
 
@@ -923,8 +923,8 @@ func TestDojoAlertsStatusGroupedText(t *testing.T) {
 		fail bool
 	}{
 		{
-			title: "dojo.alerts.status_grouped_text with firing & resolved",
-			in:    `{{ template "dojo.alerts.status_grouped_text" .Alerts }}`,
+			title: "dojo.alerts.status_title_list with firing & resolved",
+			in:    `{{ template "dojo.alerts.status_title_list" .Alerts }}`,
 			data: Data{
 				Alerts: Alerts{
 					{
@@ -933,10 +933,6 @@ func TestDojoAlertsStatusGroupedText(t *testing.T) {
 							"alertname": "AlertName1",
 							"label1":    "value1",
 							"label2":    "value2",
-						},
-						Annotations: KV{
-							"annotation1": "value1",
-							"annotation2": "value2",
 						},
 						GeneratorURL: "http://generator.url/",
 					},
@@ -946,33 +942,21 @@ func TestDojoAlertsStatusGroupedText(t *testing.T) {
 							"label1": "value1",
 							"label2": "value2",
 						},
-						Annotations: KV{
-							"annotation1": "value1",
-							"annotation2": "value2",
-						},
 						GeneratorURL: "http://generator.url/",
 					},
 				},
 			},
 			exp: "FIRING:\n" +
 				"\n" +
-				"[AlertName1] (label1=value1 label2=value2)\n" +
-				"Annotations:\n" +
-				"annotation1: value1\n" +
-				"annotation2: value2\n" +
-				"http://generator.url/\n" +
+				"- [AlertName1] (label1=value1 label2=value2)\n" +
 				"\n" +
 				"RESOLVED:\n" +
 				"\n" +
-				"(label1=value1 label2=value2)\n" +
-				"Annotations:\n" +
-				"annotation1: value1\n" +
-				"annotation2: value2\n" +
-				"http://generator.url/",
+				"- (label1=value1 label2=value2)",
 		},
 		{
-			title: "dojo.alerts.status_grouped_text with only firing",
-			in:    `{{ template "dojo.alerts.status_grouped_text" .Alerts }}`,
+			title: "dojo.alerts.status_title_list with only firing",
+			in:    `{{ template "dojo.alerts.status_title_list" .Alerts }}`,
 			data: Data{
 				Alerts: Alerts{
 					{
@@ -982,10 +966,6 @@ func TestDojoAlertsStatusGroupedText(t *testing.T) {
 							"label1":    "value1",
 							"label2":    "value2",
 						},
-						Annotations: KV{
-							"annotation1": "value1",
-							"annotation2": "value2",
-						},
 						GeneratorURL: "http://generator.url/",
 					},
 					{
@@ -994,25 +974,43 @@ func TestDojoAlertsStatusGroupedText(t *testing.T) {
 							"label1": "value1",
 							"label2": "value2",
 						},
-						Annotations: KV{
-							"annotation1": "value1",
-							"annotation2": "value2",
+						GeneratorURL: "http://generator.url/",
+					},
+				},
+			},
+			exp: "FIRING:\n" +
+				"\n" +
+				"- [AlertName1] (label1=value1 label2=value2)\n" +
+				"- (label1=value1 label2=value2)",
+		},
+		{
+			title: "dojo.alerts.status_title_list with only resolved",
+			in:    `{{ template "dojo.alerts.status_title_list" .Alerts }}`,
+			data: Data{
+				Alerts: Alerts{
+					{
+						Status: "resolved",
+						Labels: KV{
+							"alertname": "AlertName1",
+							"label1":    "value1",
+							"label2":    "value2",
+						},
+						GeneratorURL: "http://generator.url/",
+					},
+					{
+						Status: "resolved",
+						Labels: KV{
+							"label1": "value1",
+							"label2": "value2",
 						},
 						GeneratorURL: "http://generator.url/",
 					},
 				},
 			},
-			exp: "[AlertName1] (label1=value1 label2=value2)\n" +
-				"Annotations:\n" +
-				"annotation1: value1\n" +
-				"annotation2: value2\n" +
-				"http://generator.url/\n" +
+			exp: "RESOLVED:\n" +
 				"\n" +
-				"(label1=value1 label2=value2)\n" +
-				"Annotations:\n" +
-				"annotation1: value1\n" +
-				"annotation2: value2\n" +
-				"http://generator.url/",
+				"- [AlertName1] (label1=value1 label2=value2)\n" +
+				"- (label1=value1 label2=value2)",
 		},
 	} {
 		tc := tc

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -392,6 +392,82 @@ func TestTemplateExpansion(t *testing.T) {
 	}
 }
 
+func TestDojoEmoji(t *testing.T) {
+	tmpl, err := FromGlobs()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		title string
+		in    string
+		data  interface{}
+
+		exp  string
+		fail bool
+	}{
+		{
+			title: "dojo.emoji with firing high urgency alerts",
+			in:    `{{ template "dojo.emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "high",
+				},
+			},
+			exp: "💥",
+		},
+		{
+			title: "dojo.emoji with firing low urgency alerts",
+			in:    `{{ template "dojo.emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "low",
+				},
+			},
+			exp: "⚠️",
+		},
+		{
+			title: "dojo.emoji with firing bad urgency alerts",
+			in:    `{{ template "dojo.emoji" . }}`,
+			data: Data{
+				Status: "firing",
+				CommonLabels: KV{
+					"urgency": "bad",
+				},
+			},
+			exp: "💩",
+		},
+		{
+			title: "dojo.emoji with firing no urgency alerts",
+			in:    `{{ template "dojo.emoji" . }}`,
+			data: Data{
+				Status: "firing",
+			},
+			exp: "💩",
+		},
+		{
+			title: "dojo.emoji with non firing alerts",
+			in:    `{{ template "dojo.emoji" . }}`,
+			data: Data{
+				Status: "resolved",
+			},
+			exp: "👌",
+		},
+	} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			f := tmpl.ExecuteTextString
+			got, err := f(globalDojoTemplate+tc.in, tc.data)
+			if tc.fail {
+				require.NotNil(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, got)
+		})
+	}
+}
+
 func TestDojoSubjectStableText(t *testing.T) {
 	tmpl, err := FromGlobs()
 	require.NoError(t, err)
@@ -1138,55 +1214,6 @@ func TestDojoSlack(t *testing.T) {
 		exp  string
 		fail bool
 	}{
-		{
-			title: "dojo.slack.icon_emoji with firing high urgency alerts",
-			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
-			data: Data{
-				Status: "firing",
-				CommonLabels: KV{
-					"urgency": "high",
-				},
-			},
-			exp: ":boom:",
-		},
-		{
-			title: "dojo.slack.icon_emoji with firing low urgency alerts",
-			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
-			data: Data{
-				Status: "firing",
-				CommonLabels: KV{
-					"urgency": "low",
-				},
-			},
-			exp: ":warning:",
-		},
-		{
-			title: "dojo.slack.icon_emoji with firing bad urgency alerts",
-			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
-			data: Data{
-				Status: "firing",
-				CommonLabels: KV{
-					"urgency": "bad",
-				},
-			},
-			exp: ":shit:",
-		},
-		{
-			title: "dojo.slack.icon_emoji with firing no urgency alerts",
-			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
-			data: Data{
-				Status: "firing",
-			},
-			exp: ":shit:",
-		},
-		{
-			title: "dojo.slack.icon_emoji with non firing alerts",
-			in:    `{{ template "dojo.slack.icon_emoji" . }}`,
-			data: Data{
-				Status: "resolved",
-			},
-			exp: ":ok_hand:",
-		},
 		{
 			title: "dojo.slack.fallback",
 			in:    `{{ template "dojo.slack.fallback" . }}`,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -749,6 +749,56 @@ func TestDojoAlertText(t *testing.T) {
 	}
 }
 
+func TestDojoAlertsTitleList(t *testing.T) {
+	tmpl, err := FromGlobs()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		title string
+		in    string
+		data  interface{}
+
+		exp  string
+		fail bool
+	}{
+		{
+			title: "dojo.alert.title",
+			in:    `{{ template "dojo.alerts.title_list" .Alerts }}`,
+			data: Data{
+				Alerts: Alerts{
+					Alert{
+						Labels: KV{
+							"alertname": "AlertName",
+							"label1":    "value1",
+							"label2":    "value2",
+						},
+					},
+					Alert{
+						Labels: KV{
+							"alertname": "AlertName",
+						},
+					},
+				},
+			},
+			exp: "- [AlertName] (label1=value1 label2=value2)\n" +
+			"- [AlertName]\n",
+		},
+
+	} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			f := tmpl.ExecuteTextString
+			got, err := f(globalDojoTemplate+tc.in, tc.data)
+			if tc.fail {
+				require.NotNil(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, got)
+		})
+	}
+}
+
 func TestDojoAlertsStatusGroupedText(t *testing.T) {
 	tmpl, err := FromGlobs()
 	require.NoError(t, err)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1055,7 +1055,7 @@ func TestDojoAlertsUrlFiring(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/list?" +
+			exp: "https://example.grafana.net/alerting/list?" +
 				"dataSource=DATASOURCE_NAME&" +
 				"queryString=" +
 				"tenant%3Dexample," +
@@ -1079,7 +1079,7 @@ func TestDojoAlertsUrlFiring(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/list?" +
+			exp: "https://example.grafana.net/alerting/list?" +
 				"dataSource=DATASOURCE_NAME&" +
 				"queryString=" +
 				"tenant%3Dexample," +
@@ -1100,7 +1100,7 @@ func TestDojoAlertsUrlFiring(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/list?" +
+			exp: "https://example.grafana.net/alerting/list?" +
 				"dataSource=DATASOURCE_NAME&" +
 				"queryString=" +
 				"tenant%3Dexample," +
@@ -1151,7 +1151,7 @@ func TestDojoAlertsUrlHistory(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
+			exp: "https://example.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
 				"var-data_source=DATASOURCE_NAME&" +
 				"var-tenant=example&" +
 				"var-urgency=high&" +
@@ -1172,7 +1172,7 @@ func TestDojoAlertsUrlHistory(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
+			exp: "https://example.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
 				"var-data_source=DATASOURCE_NAME&" +
 				"var-tenant=example&" +
 				"var-label=urgency%7C!~%7C%5E(high__gfp__low)$&" +
@@ -1190,7 +1190,7 @@ func TestDojoAlertsUrlHistory(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
+			exp: "https://example.grafana.net/d/luyBQ9Y7z/?orgId=1&" +
 				"var-data_source=DATASOURCE_NAME&" +
 				"var-tenant=example&" +
 				"var-urgency=high&",
@@ -1238,7 +1238,7 @@ func TestDojoAlertsUrlNewSilence(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/silence/new?" +
+			exp: "https://example.grafana.net/alerting/silence/new?" +
 				"alertmanager=ALERTMANAGER_NAME&" +
 				"matcher=tenant%3Dexample&" +
 				"matcher=urgency%3Dhigh&" +
@@ -1259,7 +1259,7 @@ func TestDojoAlertsUrlNewSilence(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/silence/new?" +
+			exp: "https://example.grafana.net/alerting/silence/new?" +
 				"alertmanager=ALERTMANAGER_NAME&" +
 				"matcher=tenant%3Dexample&" +
 				"matcher=urgency!~%5E(high|low)$&" +
@@ -1277,7 +1277,7 @@ func TestDojoAlertsUrlNewSilence(t *testing.T) {
 					"be":        "used",
 				},
 			},
-			exp: "https://paymentsense.grafana.net/alerting/silence/new?" +
+			exp: "https://example.grafana.net/alerting/silence/new?" +
 				"alertmanager=ALERTMANAGER_NAME&" +
 				"matcher=tenant%3Dexample&" +
 				"matcher=urgency%3Dhigh&",
@@ -1456,7 +1456,7 @@ func TestDojoSlack(t *testing.T) {
 					"urgency": "low",
 				},
 			},
-			exp: "example: low urgency alerts firing | https://paymentsense.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,&ruleType=alerting&alertState=firing",
+			exp: "example: low urgency alerts firing | https://example.grafana.net/alerting/list?dataSource=DATASOURCE_NAME&queryString=tenant%3Dexample,urgency%3Dlow,&ruleType=alerting&alertState=firing",
 		},
 		{
 			title: "dojo.slack.color with firing high urgency alerts",


### PR DESCRIPTION
Various improvements:

- stable_subject
  - Stop using receiver name, as this is not meant for end users.
  - Use tenant & urgency instead.
- Add `dojo.emoji` in place of `dojo.slack.icon_emoji`.
  - Shareable by Slack & PagerDuty.
- Extract `dojo.alerts.url.*.title`.
  - Shareable by Slack & PagerDuty.
- Add `dojo.alert.title` & `dojo.alerts.title_list` and `dojo.alerts.status_title_list`.
  - Useful at Slack messages, that can't handle long texts with all alert annotations and URLs.
- Template variables: Grafana URL, Data Source & AlertManager.